### PR TITLE
Improve nolineString computed property

### DIFF
--- a/LaurineGenerator.swift
+++ b/LaurineGenerator.swift
@@ -871,10 +871,9 @@ private extension String {
     
     
     var nolineString: String {
-        
-        return self.stringByReplacingOccurrencesOfString("\n", withString: "")
-                   .stringByReplacingOccurrencesOfString("\r", withString: "")
-        
+        return self.componentsSeparatedByCharactersInSet(NSCharacterSet.newlineCharacterSet())
+            .filter { !$0.isEmpty }
+            .joinWithSeparator(" ")
     }
     
     


### PR DESCRIPTION
Suggested improvement to `nolineString`:

Strings that are divided by newlines, without spaces, appear strangely.

Currently: `"Hello\n\neverybody!"` -> `Helloeverybody!`
New: `"Hello\n\neverybody!"` -> `Hello everybody!`