### PR TITLE
Trim Dots

### DIFF
--- a/Example/Laurine/Classes/Generated/Localizations.swift
+++ b/Example/Laurine/Classes/Generated/Localizations.swift
@@ -34,44 +34,6 @@ private extension String {
 public struct Localizations {
 
 
-    public struct DetailScreen {
-
-    
-        public struct Misc {
-
-                    /// Base translation: * Yes, this contributor is awesome
-            public static var LoveNote : String = "DetailScreen.Misc.LoveNote".localized
-
-        }
-
-        public struct Stats {
-
-                    /// Base translation: Repositories
-            public static var Repositories : String = "DetailScreen.Stats.Repositories".localized
-
-            /// Base translation: Following
-            public static var Following : String = "DetailScreen.Stats.Following".localized
-
-            /// Base translation: Followers
-            public static var Followers : String = "DetailScreen.Stats.Followers".localized
-
-        }
-
-        public struct Buttons {
-
-                    /// Base translation: Check my profile on GitHub.com >
-            public static var GITHubProfile : String = "DetailScreen.Buttons.GITHubProfile".localized
-
-        }
-
-        public struct NavigationBar {
-
-                    /// Base translation: User profile
-            public static var Title : String = "DetailScreen.NavigationBar.Title".localized
-
-        }
-    }
-
     public struct Contributors {
 
             /// Base translation: This is the list of people who contributed with their work to make Laurine Better - it is also great example of how to use it, and my way how to say thank you!
@@ -148,5 +110,50 @@ public struct Localizations {
                 }
             }
         }
+    }
+
+    public struct DetailScreen {
+
+    
+        public struct Misc {
+
+                    /// Base translation: * Yes, this contributor is awesome
+            public static var LoveNote : String = "DetailScreen.Misc.LoveNote".localized
+
+        }
+
+        public struct Stats {
+
+                    /// Base translation: Repositories
+            public static var Repositories : String = "DetailScreen.Stats.Repositories".localized
+
+            /// Base translation: Following
+            public static var Following : String = "DetailScreen.Stats.Following".localized
+
+            /// Base translation: Followers
+            public static var Followers : String = "DetailScreen.Stats.Followers".localized
+
+        }
+
+        public struct Buttons {
+
+                    /// Base translation: Check my profile on GitHub.com >
+            public static var GITHubProfile : String = "DetailScreen.Buttons.GITHubProfile".localized
+
+        }
+
+        public struct NavigationBar {
+
+                    /// Base translation: User profile
+            public static var Title : String = "DetailScreen.NavigationBar.Title".localized
+
+        }
+    }
+
+    public struct Special_Cases_Whitespaces__Foo_ {
+
+            /// Base translation: Special Cases Whitespaces  Foo.Bar 
+        public static var _Bar_ : String = "Special Cases Whitespaces  Foo . Bar ".localized
+
     }
 }

--- a/Example/Laurine/Classes/Generated/Localizations.swift
+++ b/Example/Laurine/Classes/Generated/Localizations.swift
@@ -69,17 +69,18 @@ public struct Localizations {
 
     public struct SpecialCases {
 
-    
-        public struct General {
+            /// Base translation: SpecialCases.DotAtEnd.
+        public static var DotAtEnd : String = "SpecialCases.DotAtEnd.".localized
 
-        
-            public struct Errors {
+        /// Base translation: .SpecialCases.DotAtBeginning
+        public static var DotAtBeginning : String = ".SpecialCases.DotAtBeginning".localized
 
-                            /// Base translation: I start with number
-                public static var _1StartWithNumber : String = "SpecialCases.General.Errors.1StartWithNumber".localized
+        /// Base translation: SpecialCases...SeveralDotsInTheMiddle
+        public static var SeveralDotsInTheMiddle : String = "SpecialCases...SeveralDotsInTheMiddle".localized
 
-            }
-        }
+        /// Base translation: .SpecialCases.DotAtBeginningAndEnd.
+        public static var DotAtBeginningAndEnd : String = ".SpecialCases.DotAtBeginningAndEnd.".localized
+
 
         public struct Swift {
 
@@ -108,6 +109,17 @@ public struct Localizations {
                     public static var YES : String = "SpecialCases.ObjC.Errors.IamKeyword.YES".localized
 
                 }
+            }
+        }
+
+        public struct General {
+
+        
+            public struct Errors {
+
+                            /// Base translation: I start with number
+                public static var _1StartWithNumber : String = "SpecialCases.General.Errors.1StartWithNumber".localized
+
             }
         }
     }
@@ -150,10 +162,10 @@ public struct Localizations {
         }
     }
 
-    public struct Special_Cases_Whitespaces__Foo_ {
+    public struct Special_Cases_Whitespaces__Foo {
 
             /// Base translation: Special Cases Whitespaces  Foo.Bar 
-        public static var _Bar_ : String = "Special Cases Whitespaces  Foo . Bar ".localized
+        public static var Bar_ : String = "Special Cases Whitespaces  Foo.Bar ".localized
 
     }
 }

--- a/Example/Laurine/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Example/Laurine/Resources/Localizations/en.lproj/Localizable.strings
@@ -37,3 +37,8 @@
 "SpecialCases.Swift.Errors.IamKeyword.true" = "I am Swift Keyword";
 
 "Special Cases Whitespaces  Foo.Bar " = "Special Cases Whitespaces  Foo.Bar ";
+
+".SpecialCases.DotAtBeginning" = ".SpecialCases.DotAtBeginning";
+"SpecialCases.DotAtEnd." = "SpecialCases.DotAtEnd.";
+".SpecialCases.DotAtBeginningAndEnd." = ".SpecialCases.DotAtBeginningAndEnd.";
+"SpecialCases...SeveralDotsInTheMiddle" = "SpecialCases...SeveralDotsInTheMiddle";

--- a/Example/Laurine/Resources/Localizations/en.lproj/Localizable.strings
+++ b/Example/Laurine/Resources/Localizations/en.lproj/Localizable.strings
@@ -35,3 +35,5 @@
 "SpecialCases.General.Errors.1StartWithNumber" = "I start with number";
 "SpecialCases.ObjC.Errors.IamKeyword.YES" = "I am Objc Keyword";
 "SpecialCases.Swift.Errors.IamKeyword.true" = "I am Swift Keyword";
+
+"Special Cases Whitespaces  Foo.Bar " = "Special Cases Whitespaces  Foo.Bar ";

--- a/LaurineGenerator.swift
+++ b/LaurineGenerator.swift
@@ -798,14 +798,16 @@ private extension NSMutableDictionary {
         let baseDelimiter = "."
         forKeyPath = forKeyPath.stringByReplacingOccurrencesOfString(delimiter, withString: baseDelimiter, options: .LiteralSearch, range: nil)
         
-        // There is no keypath, just assign object
-        if forKeyPath.rangeOfString(baseDelimiter) == nil {
-            onObject.setObject(object, forKey: forKeyPath);
-        }
-        
         // Create path components separated by delimiter (. by default) and get key for root object
-        let pathComponents : Array<String> = forKeyPath.componentsSeparatedByString(baseDelimiter);
-        let rootKey : String = pathComponents[0];
+		// filter empty path components, these can be caused by delimiter at beginning/end, or multiple consecutive delimiters in the middle
+		let pathComponents : Array<String> = forKeyPath.componentsSeparatedByString(baseDelimiter).filter({ $0.characters.count > 0 })
+		forKeyPath = pathComponents.joinWithSeparator(baseDelimiter)
+        let rootKey : String = pathComponents[0]
+		
+		if pathComponents.count == 1 {
+			onObject.setObject(object, forKey: rootKey)
+		}
+		
         let replacementDictionary : NSMutableDictionary = NSMutableDictionary();
         
         // Store current state for further replacement

--- a/LaurineGenerator.swift
+++ b/LaurineGenerator.swift
@@ -758,6 +758,26 @@ private extension String {
         
         return copy
     }
+	
+	func replacedNonAlphaNumericCharacters(replacement: Character) -> String {
+		
+		return String( self.characters.map { NSCharacterSet.alphanumericCharacterSet().containsCharacter($0) ? $0 : replacement } )
+	}
+	
+}
+
+private extension NSCharacterSet {
+	
+	// thanks to http://stackoverflow.com/a/27698155/354018
+	func containsCharacter(c: Character) -> Bool {
+		
+		let s = String(c)
+		let ix = s.startIndex
+		let ix2 = s.endIndex
+		let result = s.rangeOfCharacterFromSet(self, options: [], range: ix..<ix2)
+		return result != nil
+	}
+	
 }
 
 private extension NSMutableDictionary {
@@ -1160,11 +1180,14 @@ class Localization {
     
     
     private func variableName(string : String, lang : Runtime.ExportLanguage) -> String {
-        
+	
+		// . is not allowed, nested structure expanding must take place before calling this function
+		let legalCharacterString = string.replacedNonAlphaNumericCharacters("_")
+		
         if self.autocapitalize {
-            return (string.isFirstLetterDigit() || string.isReservedKeyword(lang) ? "_" + string.camelCasedString : string.camelCasedString)
+            return (legalCharacterString.isFirstLetterDigit() || legalCharacterString.isReservedKeyword(lang) ? "_" + legalCharacterString.camelCasedString : legalCharacterString.camelCasedString)
         } else {
-            return (string.isFirstLetterDigit() || string.isReservedKeyword(lang) ? "_" + string : string)
+            return (legalCharacterString.isFirstLetterDigit() || legalCharacterString.isReservedKeyword(lang) ? "_" + string : legalCharacterString)
         }
     }
     


### PR DESCRIPTION
Fixes several special cases:

```
".SpecialCases.DotAtBeginning" = ".SpecialCases.DotAtBeginning";
"SpecialCases.DotAtEnd." = "SpecialCases.DotAtEnd.";
".SpecialCases.DotAtBeginningAndEnd." = ".SpecialCases.DotAtBeginningAndEnd.";
"SpecialCases...SeveralDotsInTheMiddle" = "SpecialCases...SeveralDotsInTheMiddle";
```

This builds upon #27