### PR TITLE
Remove external name for value1

### DIFF
--- a/Example/Laurine/Classes/Generated/Localizations.swift
+++ b/Example/Laurine/Classes/Generated/Localizations.swift
@@ -35,7 +35,7 @@ public struct Localizations {
                 public static var Singular : String = NSLocalizedString("Contributors.Contributor.Contributed.Singular", tableName: nil, bundle: Bundle.main, value: "", comment: "")
 
                 /// Base translation: %d contributions
-                public static func Plural(value1 : Int) -> String {
+                public static func Plural(_ value1 : Int) -> String {
                     return String(format: NSLocalizedString("Contributors.Contributor.Contributed.Plural", tableName: nil, bundle: Bundle.main, value: "", comment: ""), value1)
                 }
 

--- a/Example/Laurine/Classes/Views/Cells/ContributorCell.swift
+++ b/Example/Laurine/Classes/Views/Cells/ContributorCell.swift
@@ -55,9 +55,9 @@ class ContributorCell: UITableViewCell {
         self.personNameLb.text = contributor.username
         
         // Set number of contribution
-        //self.personContributions.text = contributor.contributions == 1 ?
-        //                                Localizations.Contributors.Contributor.Contributed.Singular :
-        //                                 Localizations.Contributors.Contributor.Contributed.Plural(contributor.contributions)
+        self.personContributions.text = contributor.contributions == 1 ?
+                                        Localizations.Contributors.Contributor.Contributed.Singular :
+                                         Localizations.Contributors.Contributor.Contributed.Plural(contributor.contributions)
         
         // Set profile picture, if available
         if let profilePictureURL = URL(string: contributor.avatarURL) {

--- a/LaurineGenerator.swift
+++ b/LaurineGenerator.swift
@@ -1470,7 +1470,7 @@ class Localization {
         }
         let methodParamsString = methodParams.joined(separator: ", ")
         
-        methodHeaderParams = methodHeaderParams.trimmingCharacters(in: CharacterSet(charactersIn: ", _"))
+        methodHeaderParams = methodHeaderParams.trimmingCharacters(in: CharacterSet(charactersIn: ", "))
         return TemplateFactory.templateForSwiftFuncWithName(name: self.variableName(string: methodName, lang: .Swift), key: key, table: table, baseTranslation : baseTranslation, methodHeader: methodHeaderParams, params: methodParamsString, contentLevel: contentLevel)
     }
     


### PR DESCRIPTION
Due to Swift 3 changes, the external name is currently required for the first value of strings with format specifiers. 

For Example:
`Localizations.SomeText(value1: "foo", "bar", "baz")`

For consistency, this should be changed back to:
`Localizations.SomeText("foo", "bar", "baz")`