### PR TITLE
Use default values for NSLocalizedString

### DIFF
--- a/Example/Laurine/Classes/Generated/Localizations.swift
+++ b/Example/Laurine/Classes/Generated/Localizations.swift
@@ -20,10 +20,10 @@ public struct Localizations {
     public struct Contributors {
 
         /// Base translation: This is the list of people who contributed with their work to make Laurine Better - it is also great example of how to use it, and my way how to say thank you!
-        public static var Header : String = NSLocalizedString("Contributors.Header", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        public static var Header : String = NSLocalizedString("Contributors.Header", comment: "")
 
         /// Base translation: Thanks everyone! You rock!
-        public static var Footer : String = NSLocalizedString("Contributors.Footer", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        public static var Footer : String = NSLocalizedString("Contributors.Footer", comment: "")
 
 
         public struct Contributor {
@@ -32,11 +32,11 @@ public struct Localizations {
             public struct Contributed {
 
                 /// Base translation: 1 contribution
-                public static var Singular : String = NSLocalizedString("Contributors.Contributor.Contributed.Singular", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+                public static var Singular : String = NSLocalizedString("Contributors.Contributor.Contributed.Singular", comment: "")
 
                 /// Base translation: %d contributions
                 public static func Plural(value1 : Int) -> String {
-                    return String(format: NSLocalizedString("Contributors.Contributor.Contributed.Plural", tableName: nil, bundle: Bundle.main, value: "", comment: ""), value1)
+                    return String(format: NSLocalizedString("Contributors.Contributor.Contributed.Plural", comment: ""), value1)
                 }
 
             }
@@ -45,7 +45,7 @@ public struct Localizations {
         public struct NavigationBar {
 
             /// Base translation: Laurine Lovers
-            public static var Title : String = NSLocalizedString("Contributors.NavigationBar.Title", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+            public static var Title : String = NSLocalizedString("Contributors.NavigationBar.Title", comment: "")
 
         }
     }
@@ -53,19 +53,19 @@ public struct Localizations {
     public struct SpecialCases {
 
         /// Base translation: SpecialCases.DotAtEnd.
-        public static var DotAtEnd : String = NSLocalizedString("SpecialCases.DotAtEnd.", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        public static var DotAtEnd : String = NSLocalizedString("SpecialCases.DotAtEnd.", comment: "")
 
         /// Base translation: .SpecialCases.DotAtBeginning
-        public static var DotAtBeginning : String = NSLocalizedString(".SpecialCases.DotAtBeginning", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        public static var DotAtBeginning : String = NSLocalizedString(".SpecialCases.DotAtBeginning", comment: "")
 
         /// Base translation: Special Cases - Several Dots In The Middle
-        public static var SeveralDotsInTheMiddle : String = NSLocalizedString("SpecialCases...SeveralDotsInTheMiddle", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        public static var SeveralDotsInTheMiddle : String = NSLocalizedString("SpecialCases...SeveralDotsInTheMiddle", comment: "")
 
         /// Base translation: Special Cases Text With New Line
-        public static var TextWithNewLine : String = NSLocalizedString("SpecialCases.TextWithNewLine", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        public static var TextWithNewLine : String = NSLocalizedString("SpecialCases.TextWithNewLine", comment: "")
 
         /// Base translation: Special Cases - DotAtBeginningAndEnd
-        public static var DotAtBeginningAndEnd : String = NSLocalizedString(".SpecialCases.DotAtBeginningAndEnd.", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        public static var DotAtBeginningAndEnd : String = NSLocalizedString(".SpecialCases.DotAtBeginningAndEnd.", comment: "")
 
 
         public struct Swift {
@@ -77,7 +77,7 @@ public struct Localizations {
                 public struct IamKeyword {
 
                     /// Base translation: I am Swift Keyword
-                    public static var _true : String = NSLocalizedString("SpecialCases.Swift.Errors.IamKeyword.true", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+                    public static var _true : String = NSLocalizedString("SpecialCases.Swift.Errors.IamKeyword.true", comment: "")
 
                 }
             }
@@ -92,7 +92,7 @@ public struct Localizations {
                 public struct IamKeyword {
 
                     /// Base translation: I am Objc Keyword
-                    public static var YES : String = NSLocalizedString("SpecialCases.ObjC.Errors.IamKeyword.YES", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+                    public static var YES : String = NSLocalizedString("SpecialCases.ObjC.Errors.IamKeyword.YES", comment: "")
 
                 }
             }
@@ -104,7 +104,7 @@ public struct Localizations {
             public struct Errors {
 
                 /// Base translation: I start with number
-                public static var _1StartWithNumber : String = NSLocalizedString("SpecialCases.General.Errors.1StartWithNumber", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+                public static var _1StartWithNumber : String = NSLocalizedString("SpecialCases.General.Errors.1StartWithNumber", comment: "")
 
             }
         }
@@ -116,34 +116,34 @@ public struct Localizations {
         public struct Misc {
 
             /// Base translation: * Yes, this contributor is awesome
-            public static var LoveNote : String = NSLocalizedString("DetailScreen.Misc.LoveNote", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+            public static var LoveNote : String = NSLocalizedString("DetailScreen.Misc.LoveNote", comment: "")
 
         }
 
         public struct Stats {
 
             /// Base translation: Repositories
-            public static var Repositories : String = NSLocalizedString("DetailScreen.Stats.Repositories", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+            public static var Repositories : String = NSLocalizedString("DetailScreen.Stats.Repositories", comment: "")
 
             /// Base translation: Following
-            public static var Following : String = NSLocalizedString("DetailScreen.Stats.Following", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+            public static var Following : String = NSLocalizedString("DetailScreen.Stats.Following", comment: "")
 
             /// Base translation: Followers
-            public static var Followers : String = NSLocalizedString("DetailScreen.Stats.Followers", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+            public static var Followers : String = NSLocalizedString("DetailScreen.Stats.Followers", comment: "")
 
         }
 
         public struct Buttons {
 
             /// Base translation: Check my profile on GitHub.com >
-            public static var GITHubProfile : String = NSLocalizedString("DetailScreen.Buttons.GITHubProfile", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+            public static var GITHubProfile : String = NSLocalizedString("DetailScreen.Buttons.GITHubProfile", comment: "")
 
         }
 
         public struct NavigationBar {
 
             /// Base translation: User profile
-            public static var Title : String = NSLocalizedString("DetailScreen.NavigationBar.Title", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+            public static var Title : String = NSLocalizedString("DetailScreen.NavigationBar.Title", comment: "")
 
         }
     }
@@ -151,7 +151,7 @@ public struct Localizations {
     public struct Special_Cases_Whitespaces__Foo {
 
         /// Base translation: Special Cases Whitespaces  Foo.Bar 
-        public static var Bar_ : String = NSLocalizedString("Special Cases Whitespaces  Foo.Bar ", tableName: nil, bundle: Bundle.main, value: "", comment: "")
+        public static var Bar_ : String = NSLocalizedString("Special Cases Whitespaces  Foo.Bar ", comment: "")
 
     }
 }

--- a/LaurineGenerator.swift
+++ b/LaurineGenerator.swift
@@ -1848,7 +1848,7 @@ class TemplateFactory {
     class func templateForSwiftStaticVarWithName(name : String, key : String, table: String?, baseTranslation : String, contentLevel : Int) -> String {
         let tableName = table != nil ? "\"\(table!)\"" : "nil"
         return TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "/// Base translation: \(baseTranslation)\n"
-             + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "public static var \(name) : String = NSLocalizedString(\"\(key)\", tableName: \(tableName), bundle: Bundle.main, value: \"\", comment: \"\")\n"
+             + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "public static var \(name) : String = NSLocalizedString(\"\(key)\", comment: \"\")\n"
     }
     
     
@@ -1856,7 +1856,7 @@ class TemplateFactory {
         let tableName = table != nil ? "\"\(table!)\"" : "nil"
         return TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "/// Base translation: \(baseTranslation)\n"
              + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "public static func \(name)(\(methodHeader)) -> String {\n"
-             + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel + 1) + "return String(format: NSLocalizedString(\"\(key)\", tableName: \(tableName), bundle: Bundle.main, value: \"\", comment: \"\"), \(params))\n"
+             + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel + 1) + "return String(format: NSLocalizedString(\"\(key)\", comment: \"\"), \(params))\n"
              + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "}\n"
     }
     


### PR DESCRIPTION
Clean up the generated localizations file by taking advantage of the newly-added default values.