### PR TITLE
Address warnings to use `_` instead of unused named constants

### DIFF
--- a/LaurineGenerator.swift
+++ b/LaurineGenerator.swift
@@ -1846,14 +1846,14 @@ class TemplateFactory {
     
     
     class func templateForSwiftStaticVarWithName(name : String, key : String, table: String?, baseTranslation : String, contentLevel : Int) -> String {
-        let tableName = table != nil ? "\"\(table!)\"" : "nil"
+        let _ = table != nil ? "\"\(table!)\"" : "nil"
         return TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "/// Base translation: \(baseTranslation)\n"
              + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "public static var \(name) : String = NSLocalizedString(\"\(key)\", comment: \"\")\n"
     }
     
     
     class func templateForSwiftFuncWithName(name : String, key : String, table: String?, baseTranslation : String, methodHeader : String, params : String, contentLevel : Int) -> String {
-        let tableName = table != nil ? "\"\(table!)\"" : "nil"
+        let _ = table != nil ? "\"\(table!)\"" : "nil"
         return TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "/// Base translation: \(baseTranslation)\n"
              + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel) + "public static func \(name)(\(methodHeader)) -> String {\n"
              + TemplateFactory.contentIndentForLevel(contentLevel: contentLevel + 1) + "return String(format: NSLocalizedString(\"\(key)\", comment: \"\"), \(params))\n"


### PR DESCRIPTION
This addresses two warnings (both the same, for two occurrences):

`warning: initialization of immutable value 'tableName' was never used; consider replacing with assignment to '_' or removing it`