### PR TITLE
Support for Swift 3.2 and Xcode 9

### DIFF
--- a/LaurineGenerator.swift
+++ b/LaurineGenerator.swift
@@ -347,9 +347,9 @@ open class CommandLine {
             }
             
             /* Remove attached argument from flag */
-            let splitFlag = flagWithArg.split(by: ArgumentAttacher, maxSplits: 1)
-            let flag = splitFlag[0]
-            let attachedArg: String? = splitFlag.count == 2 ? splitFlag[1] : nil
+            let splitFlag = flagWithArg.split(separator: ArgumentAttacher, maxSplits: 1)
+            let flag = String(splitFlag[0])
+            let attachedArg: String? = splitFlag.count == 2 ? String(splitFlag[1]) : nil
             
             var flagMatched = false
             for option in _options where option.flagMatch(flag) {
@@ -888,14 +888,16 @@ internal extension String {
         for i in self.characters.indices {
             let c = self[i]
             if c == by && (maxSplits == 0 || numSplits < maxSplits) {
-                s.append(self[curIdx..<i])
+                let str = String(self[curIdx..<i])
+                s.append(str)
                 curIdx = self.index(after: i)
                 numSplits += 1
             }
         }
         
         if curIdx != self.endIndex {
-            s.append(self[curIdx..<self.endIndex])
+            let str = String(self[curIdx..<self.endIndex])
+            s.append(str)
         }
         
         return s


### PR DESCRIPTION
This converts `Substring` to `String` and explicitly constructs `String` from a subscripted result.